### PR TITLE
Validate event size.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@ var type = require('component-type')
 var join = require('join-component')
 var assert = require('assert')
 
+// Segment messages can be a maximum of 32kb.
+var MAX_SIZE = 32 << 10
+
 module.exports = looselyValidateEvent
 
 /**
@@ -105,6 +108,10 @@ var genericValidationRules = {
 
 function validateGenericEvent (event) {
   assert(type(event) === 'object', 'You must pass a message object.')
+  var json = JSON.stringify(event)
+  // Strings are variable byte encoded, so json.length is not sufficient.
+  assert(Buffer.byteLength(json, 'utf8') < MAX_SIZE, 'Your message must be < 32kb.')
+
   for (var key in genericValidationRules) {
     var val = event[key]
     if (!val) continue

--- a/test.js
+++ b/test.js
@@ -256,3 +256,26 @@ test('requires userId on alias events', t => {
     })
   })
 })
+
+test('requires events to be < 32kb', t => {
+  t.throws(() => {
+    var event = {
+      type: 'track',
+      event: 'Did Something',
+      userId: 'banana',
+      properties: {}
+    }
+    for (var i = 0; i < 10000; i++) {
+      event.properties[i] = 'a'
+    }
+    validate(event)
+  }, 'Your message must be < 32kb.')
+
+  t.notThrows(() => {
+    validate({
+      type: 'track',
+      event: 'Did Something',
+      userId: 'banana'
+    })
+  })
+})


### PR DESCRIPTION
Segment events can be only upto 32kb in size. This validates that an event is less the JSON representation of an event is < 32kb in size.